### PR TITLE
feat(auth): add password visibility toggle for login and signup

### DIFF
--- a/apps/native/app/sign-in.tsx
+++ b/apps/native/app/sign-in.tsx
@@ -1,14 +1,16 @@
-import { useRouter } from 'expo-router';
 import { useState } from 'react';
-import { StyleSheet, Platform } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
+import { useLoginMutation } from '@repo/shared/hooks/useAuth';
+import { AuthForm as AuthFormType } from '@repo/types';
+import { useRouter } from 'expo-router';
+
+import { setAuthorization } from '@/api';
 import AuthForm from '@/components/auth/AuthForm';
 import Button from '@/components/common/Button';
 import Link from '@/components/common/Link';
+import PasswordInput from '@/components/common/PasswordInput';
 import ThemeTextInput from '@/components/common/ThemeTextInput';
 import ThemeView from '@/components/common/ThemeView';
-import { useLoginMutation } from '@repo/shared/hooks/useAuth';
-import { AuthForm as AuthFormType } from '@repo/types';
-import { setAuthorization } from '@/api';
 import { useNotifications } from '@/hooks/useNotifications';
 
 const initial = () => ({
@@ -39,8 +41,9 @@ export default function SignIn() {
       };
 
       const response = await login.mutateAsync(loginData);
+
       setAuthorization(response.accessToken);
-      router.push('/(tabs)/(afterLogin)/(routine)')
+      router.push('/(tabs)/(afterLogin)/(routine)');
     } catch {}
   };
 
@@ -49,39 +52,35 @@ export default function SignIn() {
       ...prev,
       [key]: value,
     }));
-  }
+  };
 
   return (
     <ThemeView style={styles.container}>
-      <AuthForm title='로그인'>
-        <ThemeTextInput 
-          width={250} 
+      <AuthForm title="로그인">
+        <ThemeTextInput
+          width={250}
           placeholder="아이디를 입력해주세요."
           value={form.userId}
           onChangeText={(value) => handleChange('userId', value)}
         />
-        <ThemeTextInput 
-          width={250} 
+        <PasswordInput
+          width={250}
           placeholder="비밀번호를 입력해주세요."
           value={form.password}
           onChangeText={(value) => handleChange('password', value)}
         />
-        <Button 
-          title="로그인" 
-          onPress={handleLogin}
-          style={styles.button}
-        />
-        <Link 
+        <Button title="로그인" onPress={handleLogin} style={styles.button} />
+        <Link
           href="/sign-up"
           variant="plain"
-          title='회원가입'
+          title="회원가입"
           style={styles.link}
           onPress={() => setForm(initial())}
         />
       </AuthForm>
     </ThemeView>
   );
-};
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -92,10 +91,10 @@ const styles = StyleSheet.create({
   },
 
   button: {
-    marginTop: 10
+    marginTop: 10,
   },
 
   link: {
-    alignItems: 'flex-end'
-  }
+    alignItems: 'flex-end',
+  },
 });

--- a/apps/native/app/sign-up.tsx
+++ b/apps/native/app/sign-up.tsx
@@ -1,13 +1,15 @@
-import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import { StyleSheet } from 'react-native';
+import { useJoinMutation } from '@repo/shared/hooks/useAuth';
+import { JoinForm as JoinFormType } from '@repo/types';
+import { useRouter } from 'expo-router';
+
 import AuthForm from '@/components/auth/AuthForm';
 import Button from '@/components/common/Button';
 import Link from '@/components/common/Link';
+import PasswordInput from '@/components/common/PasswordInput';
 import ThemeTextInput from '@/components/common/ThemeTextInput';
 import ThemeView from '@/components/common/ThemeView';
-import { useJoinMutation } from '@repo/shared/hooks/useAuth';
-import { JoinForm as JoinFormType } from '@repo/types';
 
 const initial = () => ({
   userId: '',
@@ -19,7 +21,9 @@ const initial = () => ({
 
 export default function SignUp() {
   const router = useRouter();
-  const [form, setForm] = useState<JoinFormType & { passwordConfirm: JoinFormType['password'] }>(initial());
+  const [form, setForm] = useState<
+    JoinFormType & { passwordConfirm: JoinFormType['password'] }
+  >(initial());
   const join = useJoinMutation();
 
   const handleJoin = async () => {
@@ -31,72 +35,71 @@ export default function SignUp() {
     }
 
     if (form.passwordConfirm !== form.password) {
-      alert("비밀번호가 다릅니다.");
+      alert('비밀번호가 다릅니다.');
       return;
     }
 
     try {
       await join.mutateAsync(form);
-      router.push('/sign-in')
+      router.push('/sign-in');
     } catch {}
   };
 
-  const handleChange = (key: (keyof JoinFormType) | 'passwordConfirm', value: string) => {
+  const handleChange = (
+    key: keyof JoinFormType | 'passwordConfirm',
+    value: string,
+  ) => {
     setForm((prev) => ({
       ...prev,
       [key]: value,
     }));
-  }
+  };
 
   return (
     <ThemeView style={styles.container}>
-      <AuthForm title='회원가입'>
-        <ThemeTextInput 
-          width={250} 
+      <AuthForm title="회원가입">
+        <ThemeTextInput
+          width={250}
           placeholder="아이디를 입력해주세요."
           value={form.userId}
           onChangeText={(value) => handleChange('userId', value)}
         />
-        <ThemeTextInput 
-          width={250} 
+        <ThemeTextInput
+          width={250}
           placeholder="닉네임을 입력해주세요."
           value={form.nickname}
           onChangeText={(value) => handleChange('nickname', value)}
         />
-        <ThemeTextInput 
-          width={250} 
+        <PasswordInput
+          width={250}
           placeholder="비밀번호를 입력해주세요."
           value={form.password}
           onChangeText={(value) => handleChange('password', value)}
         />
-        <ThemeTextInput 
-          width={250} 
+        <PasswordInput
+          width={250}
           placeholder="비밀번호를 다시 입력해주세요."
           value={form.passwordConfirm}
           onChangeText={(value) => handleChange('passwordConfirm', value)}
         />
-        <ThemeTextInput 
-          width={250} 
+        <ThemeTextInput
+          width={250}
           placeholder="직업을 입력해주세요."
           value={form.job}
           onChangeText={(value) => handleChange('job', value)}
         />
-        <Button 
-          title="회원가입" 
-          onPress={handleJoin}
-          style={styles.button}
-        />
-        <Link 
+        <Button title="회원가입" onPress={handleJoin} style={styles.button} />
+        <Link
           href="/sign-in"
           variant="plain"
-          title='로그인'
+          title="로그인"
           style={styles.link}
           onPress={() => setForm(initial())}
         />
       </AuthForm>
     </ThemeView>
   );
-};
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -107,10 +110,10 @@ const styles = StyleSheet.create({
   },
 
   button: {
-    marginTop: 10
+    marginTop: 10,
   },
 
   link: {
-    alignItems: 'flex-end'
-  }
+    alignItems: 'flex-end',
+  },
 });

--- a/apps/native/components/common/PasswordInput.tsx
+++ b/apps/native/components/common/PasswordInput.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { COLORS } from '@/theme/colors';
+
+import ThemeTextInput from './ThemeTextInput';
+
+interface PasswordInputProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder?: string;
+  width?: number;
+  autoFocus?: boolean;
+}
+
+const PasswordInput = ({
+  value,
+  onChangeText,
+  placeholder = '비밀번호를 입력해주세요.',
+  width,
+  autoFocus = false,
+}: PasswordInputProps) => {
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const colorScheme = useColorScheme();
+
+  const togglePasswordVisibility = (): void => {
+    setShowPassword((prev) => !prev);
+  };
+
+  return (
+    <View style={styles.container}>
+      <ThemeTextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        width={width}
+        autoFocus={autoFocus}
+        secureTextEntry={!showPassword}
+        style={styles.input}
+      />
+      <Pressable
+        onPress={togglePasswordVisibility}
+        style={styles.iconContainer}
+        accessibilityLabel="비밀번호 표시 토글"
+        accessibilityHint={showPassword ? '비밀번호 숨기기' : '비밀번호 보이기'}
+        accessibilityRole="button"
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      >
+        <Ionicons
+          name={showPassword ? 'eye-off' : 'eye'}
+          size={20}
+          color={COLORS[colorScheme].grey}
+        />
+      </Pressable>
+    </View>
+  );
+};
+
+export default PasswordInput;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+
+  input: {
+    flex: 1,
+  },
+
+  iconContainer: {
+    position: 'absolute',
+    right: 12,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+  },
+});


### PR DESCRIPTION
## 📋 관련 이슈
Closes #9

## 🎯 변경 사항 요약
- PasswordInput 공통 컴포넌트 생성 (secureTextEntry + 가시성 토글)
- 로그인 화면 비밀번호 필드 보안 적용
- 회원가입 화면 비밀번호/비밀번호 확인 필드 보안 적용
- Ionicons eye/eye-off 아이콘 사용
- 접근성 라벨 추가 (accessibilityLabel, accessibilityHint, accessibilityRole)
- Theme 시스템 통합 (useColorScheme, COLORS)

## 📂 주요 변경 파일
### 신규 파일
- `apps/native/components/common/PasswordInput.tsx` (82 lines)

### 수정된 파일
- `apps/native/app/sign-in.tsx` - 비밀번호 필드를 PasswordInput으로 교체
- `apps/native/app/sign-up.tsx` - 비밀번호/비밀번호 확인 필드를 PasswordInput으로 교체

## ✅ 품질 검증
- ✓ TypeScript: 통과 (오류 0개)
- ✓ ESLint: 통과 (오류 0개)
- ✓ 접근성: 통과 (accessibilityLabel, accessibilityHint, accessibilityRole 추가)
- ✓ Theme 통합: 완료 (light/dark mode 지원)
- ✓ Code formatting: 완료

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout feature/issue-9-password-security`
2. 의존성 설치: `pnpm install`
3. 앱 실행: `pnpm --filter ./apps/native dev`
4. 테스트:
   - 로그인 화면에서 비밀번호 필드 확인
   - 회원가입 화면에서 비밀번호/비밀번호 확인 필드 확인
   - 눈 아이콘 클릭하여 비밀번호 표시/숨김 토글 확인
   - iOS/Android 양쪽 플랫폼에서 동작 확인

## 🔒 보안 개선사항
- 비밀번호 필드 기본값: 마스킹됨 (secureTextEntry={true})
- 사용자가 선택적으로 비밀번호 표시 가능
- 접근성 향상으로 스크린 리더 사용자도 기능 사용 가능

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude &lt;noreply@anthropic.com&gt;