### PR TITLE
feat(theme): 다크 모드를 기본값으로 설정

### DIFF
--- a/apps/native/store/colorScheme.store.ts
+++ b/apps/native/store/colorScheme.store.ts
@@ -14,7 +14,7 @@ interface Action {
 export const useColorSchemeStore = create<ColorSchemeState & Action>()(
   persist(
     (set) => ({
-      colorScheme: 'light',
+      colorScheme: 'dark',
       setColorScheme: (colorScheme: 'light' | 'dark') => set({ colorScheme }),
     }),
     {


### PR DESCRIPTION
## 📋 관련 이슈
Closes #12

## 🎯 변경 사항 요약
앱 설정 값이 없을 때 다크 모드가 기본으로 적용되도록 변경했습니다. 기존에 저장된 사용자 설정이 있는 경우에는 해당 값을 그대로 유지합니다.

## 📂 주요 변경 파일
- `apps/native/store/colorScheme.store.ts`

## ✅ 품질 검증
- ✓ TypeScript: 통과 (해당 파일에 오류 없음)
- ✓ ESLint: 통과 (해당 파일에 오류 없음)

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout feature/issue-12-default-dark-mode`
2. 의존성 설치: `pnpm install`
3. 앱 실행: `pnpm --filter ./apps/native start`
4. 앱 데이터 초기화 후 실행하여 기본 테마가 다크 모드인지 확인

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)