### PR TITLE
fix(routine): 직접 루틴 체크 시 메이트 이름 입력 비활성화

### DIFF
--- a/apps/webApp/src/components/common/input/Input.tsx
+++ b/apps/webApp/src/components/common/input/Input.tsx
@@ -28,12 +28,12 @@ const Input = ({
   type,
   ...rest
 }: InputProps) => {
-  const disabled = rest.disabled ? 'opacity-50' : '';
+  const disabledStyle = rest.disabled ? 'opacity-50 cursor-not-allowed' : '';
 
   return (
     <input
       className={twMerge(
-        `outline-0 placeholder-gray-500 dark:placeholder-gray-400 text-gray-main dark:text-gray-200 ${type === 'date' && 'scheme-light dark:scheme-dark'}  ${variantStyle[variant]} ${sizeStyle[size]} ${disabled}`,
+        `outline-0 placeholder-gray-500 dark:placeholder-gray-400 text-gray-main dark:text-gray-200 ${type === 'date' && 'scheme-light dark:scheme-dark'}  ${variantStyle[variant]} ${sizeStyle[size]} ${disabledStyle}`,
         className,
       )}
       type={type}


### PR DESCRIPTION
## 📋 관련 이슈
Closes #13

## 🎯 변경 사항 요약
- Input 컴포넌트에 cursor-not-allowed 스타일 추가
- disabled 상태일 때 더 명확한 시각적 피드백 제공

## 📂 주요 변경 파일
- `apps/webApp/src/components/common/input/Input.tsx`

## ✅ 품질 검증
- ✓ TypeScript: 통과 (오류 0개)
- ✓ 기본 코드 스타일 검증 완료

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout fix/issue-13-disable-mate-name-direct-routine`
2. 의존성 설치: `pnpm install`
3. 앱 실행: `pnpm --filter ./apps/webApp dev`
4. 루틴 추가 화면에서 "직접 루틴 체크" 옵션 활성화
5. 메이트 이름 입력 필드가 비활성화되고 cursor가 not-allowed로 표시되는지 확인

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)