### PR TITLE
fix(routine): 주간 변경 버튼의 라우트 경로 수정

### DIFF
--- a/apps/webApp/src/components/routine/RoutineDate.tsx
+++ b/apps/webApp/src/components/routine/RoutineDate.tsx
@@ -37,10 +37,10 @@ const RoutineDate = ({ date }: RoutineDateProps) => {
         <span>{getDisplayFormatDate(endDate)}</span>
       </div>
       <div className="flex relative">
-        <Link to={`/routine?date=${beforeWeek(startDate)}`}>
+        <Link to={`/?date=${beforeWeek(startDate)}`}>
           <IconChevronLeft stroke={2} />
         </Link>
-        <Link to={`/routine?date=${afterWeek(startDate)}`}>
+        <Link to={`/?date=${afterWeek(startDate)}`}>
           <IconChevronRight stroke={2} />
         </Link>
         <div className="flex ml-4 gap-1 items-center">


### PR DESCRIPTION
## 📋 관련 이슈
Closes #19

## 🎯 변경 사항 요약
루틴 리스트 페이지의 주간 날짜 변경 화살표 버튼이 `/routine` 경로로 이동하여 404 오류가 발생하는 문제를 수정했습니다. 루틴 페이지가 메인 페이지(`/`)가 되었으므로, 화살표 버튼의 링크를 `/`로 변경했습니다.

## 📂 주요 변경 파일
- `apps/webApp/src/components/routine/RoutineDate.tsx`
  - 이전 주 버튼: `/routine?date=...` → `/?date=...`
  - 다음 주 버튼: `/routine?date=...` → `/?date=...`

## ✅ 품질 검증
- ✓ TypeScript: 통과
- ✓ 변경 사항: 최소한의 수정 (2줄)

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout fix/issue-19-route-error-weekly-change`
2. 의존성 설치: `pnpm install`
3. 웹 앱 실행: `pnpm --filter ./apps/webApp dev`
4. 루틴 리스트 페이지에서 주간 변경 화살표 버튼 클릭
5. 404 오류 없이 정상적으로 주간 변경되는지 확인

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)