### PR TITLE
fix(auth): center password toggle button vertically

### DIFF
--- a/apps/native/components/common/PasswordInput.tsx
+++ b/apps/native/components/common/PasswordInput.tsx
@@ -74,6 +74,7 @@ const styles = StyleSheet.create({
   iconContainer: {
     position: 'absolute',
     right: 12,
+    top: 0,
     height: 44,
     justifyContent: 'center',
     alignItems: 'center',

--- a/apps/webApp/src/components/common/input/PasswordInput.tsx
+++ b/apps/webApp/src/components/common/input/PasswordInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { twMerge } from 'tailwind-merge';
+
 import Input, { InputProps } from './Input';
 
 interface PasswordInputProps extends Omit<InputProps, 'type'> {
@@ -28,7 +29,8 @@ const PasswordInput = ({
         <button
           type="button"
           onClick={togglePasswordVisibility}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          className="absolute right-3 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+          style={{ top: '50%', transform: 'translateY(-50%)' }}
           aria-label="비밀번호 표시 토글"
           tabIndex={-1}
         >


### PR DESCRIPTION
## 📋 관련 이슈
Closes #29

## 🎯 변경 사항 요약
비밀번호 입력 필드의 토글 버튼을 세로 기준 중앙에 정확히 위치하도록 수정했습니다.

- **React Native**: `top: 0`을 추가하여 토글 버튼이 input의 상단부터 시작하고, `height: 44px`와 `justifyContent: 'center'`로 내부에서 수직 중앙 정렬
- **Web**: Tailwind 클래스 대신 inline style (`top: '50%', transform: 'translateY(-50%)'`)을 사용하여 확실한 수직 중앙 정렬

## 📂 주요 변경 파일
- `apps/native/components/common/PasswordInput.tsx`
- `apps/webApp/src/components/common/input/PasswordInput.tsx`

## ✅ 품질 검증
- ✓ 기본 품질 체크 통과 (Quick 모드)
- ✓ 코드 변경: 각 플랫폼별 최소한의 수정

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout fix/issue-29-password-toggle-center`
2. 의존성 설치: `pnpm install`
3. 앱 실행:
   - Native: `pnpm --filter ./apps/native dev`
   - Web: `pnpm --filter ./apps/webApp dev`
4. 비밀번호 입력 필드에서 토글 버튼이 세로 중앙에 정렬되었는지 확인

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우 Quick 모드에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)