### PR TITLE
fix(native): add safe area insets to bottom tab bar

### DIFF
--- a/apps/native/app/(tabs)/_layout.tsx
+++ b/apps/native/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Animated, Pressable } from 'react-native';
 import { type BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
 import { Tabs } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import TabBarIcon from '@/components/common/TabBarIcon';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -53,6 +54,7 @@ const AnimatedTabBarButton = ({
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const insets = useSafeAreaInsets();
 
   return (
     <>
@@ -67,8 +69,8 @@ export default function TabLayout() {
             fontWeight: 'bold',
           },
           tabBarStyle: {
-            height: 65,
-            paddingBottom: 10,
+            height: 65 + insets.bottom,
+            paddingBottom: 10 + insets.bottom,
             paddingTop: 10,
             paddingHorizontal: 20,
             justifyContent: 'center',


### PR DESCRIPTION
## 📋 관련 이슈
Closes #34

## 🎯 변경 사항 요약
하단 탭 바에 Safe Area Insets를 적용하여 스마트폰 기기의 시스템 UI에 의해 가려지는 문제를 해결했습니다.

## 📂 주요 변경 파일
- `apps/native/app/(tabs)/_layout.tsx`
  - react-native-safe-area-context의 useSafeAreaInsets 훅 추가
  - tabBarStyle의 height와 paddingBottom에 insets.bottom 적용

## ✅ 품질 검증
- ✓ Package 확인: react-native-safe-area-context 설치됨 (v5.4.0)
- ✓ Import 경로: 정확함
- ✓ 구현 방식: React Native 표준 패턴

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout fix/issue-34-하단-탭이-밑에-딱-붙어-있어서-가려지는-문제`
2. 의존성 설치: `pnpm install`
3. 앱 실행: `pnpm --filter ./apps/native dev`
4. 실제 디바이스 또는 시뮬레이터에서 하단 탭이 시스템 UI에 의해 가려지지 않는지 확인

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)