### PR TITLE
fix(routine): 루틴 리스트 날짜 년도를 2자리로 변경

### DIFF
--- a/packages/shared/utils/date-utils.ts
+++ b/packages/shared/utils/date-utils.ts
@@ -16,7 +16,7 @@ export const getFormatDate = (date: Date) => {
 };
 
 export const getDisplayFormatDate = (date: Date) => {
-  const year = date.getFullYear();
+  const year = String(date.getFullYear()).slice(-2); // 년도를 2자리로 변경
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
 


### PR DESCRIPTION
## 📋 관련 이슈
Closes #36

## 🎯 변경 사항 요약
루틴 리스트 페이지의 주간 날짜 표시 포맷을 변경했습니다.
- 기존: `yyyy년 MM월 dd일` (예: 2025년 11월 09일)
- 변경: `yy년 MM월 dd일` (예: 25년 11월 09일)

모바일 환경에서 날짜 표시가 너무 길어 가독성이 떨어지는 문제를 해결했습니다.

## 📂 주요 변경 파일
- `packages/shared/utils/date-utils.ts`

## ✅ 품질 검증
- ✓ TypeScript: 통과
- ✓ Build: 성공

## 🧪 테스트 방법
1. 브랜치 체크아웃: `git checkout fix/issue-36-루틴-리스트-날짜-년도-두자리-표현`
2. 의존성 설치: `pnpm install`
3. 웹 앱 실행: `pnpm --filter ./apps/webApp dev`
4. 네이티브 앱 실행: `pnpm --filter ./apps/native start`
5. 루틴 리스트 페이지로 이동하여 날짜 포맷 확인

## 📱 적용 범위
- ✅ 웹 애플리케이션
- ✅ 네이티브 애플리케이션

## 🤖 자동 생성됨
이 PR은 Claude Code의 GitHub 워크플로우에 의해 자동으로 생성되었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)