### PR TITLE
feat(routine): add guidance text for routine start date

### DIFF
--- a/apps/native/components/modal/RoutineFormModal.tsx
+++ b/apps/native/components/modal/RoutineFormModal.tsx
@@ -214,6 +214,7 @@ const RoutineFormModal = () => {
         <FormItem
           name="startDate"
           label="루틴 시작 날짜"
+          helpText="루틴은 월요일부터 시작됩니다"
           children={({ value, form, setValue }) => (
             <ThemeView style={styles.dateContainer} transparent>
               {form.startDate && <Typography>{form.startDate}</Typography>}

--- a/apps/webApp/src/components/routine/RoutineForm.tsx
+++ b/apps/webApp/src/components/routine/RoutineForm.tsx
@@ -221,6 +221,7 @@ const RoutineForm = ({
         name="startDate"
         className="flex flex-col gap-2 mt-5"
         label="루틴 시작 날짜"
+        helpText="루틴은 월요일부터 시작됩니다"
         children={({ value, name, onChange, form, setValue }) => (
           <Input
             type="date"


### PR DESCRIPTION
## 구현 내용
- 루틴 생성/수정 모달에 "루틴은 월요일부터 시작됩니다" 안내 문구 추가
- Native 앱 및 Web 앱 모두 적용
- FormItem helpText prop 활용으로 일관된 스타일 제공

## 주요 변경사항
- Native: RoutineFormModal.tsx (helpText 추가)
- Web: RoutineForm.tsx (helpText 추가)
- 총 2개 파일 수정, 각 파일당 1줄 추가

## 배경
사용자가 월요일이 아닌 날에 루틴을 생성하면 다음 주에만 표시되어
루틴 생성이 실패한 것으로 오해할 수 있는 UX 문제 해결

## 품질 검증
✓ TypeScript: 타입 오류 없음
✓ 코드 변경: 최소화 (각 파일 1줄 추가)
✓ 기존 코드: 영향 없음

Closes #48

🤖 Generated with Claude Code (https://claude.com/claude-code)