### PR TITLE
Fix: 친구 페이지 접속 시 친구 리스트 API 호출되도록 수정 #61

### DIFF
--- a/packages/shared/hooks/useFriend.ts
+++ b/packages/shared/hooks/useFriend.ts
@@ -17,6 +17,7 @@ export const useFetchFriendsQuery = (
   return useQuery({
     queryKey: friendKey.list(option),
     queryFn: () => fetchFriends(option),
+    refetchOnMount: 'always',
   });
 };
 


### PR DESCRIPTION
## Summary
- 친구 페이지 접속 시 친구 리스트 API를 항상 호출하도록 수정
- `useFetchFriendsQuery` 훅에 `refetchOnMount: 'always'` 옵션 추가
- 친구 승낙 후 리스트 미반영 문제 해결

## 변경 사항
| 파일 | 변경 내용 |
|------|----------|
| `packages/shared/hooks/useFriend.ts` | `refetchOnMount: 'always'` 옵션 추가 |

## 원인 분석
- 친구 승낙은 상대방 앱에서 발생하여 나의 앱에서는 이벤트를 감지할 수 없음
- 기존에는 캐시된 데이터가 있으면 API를 호출하지 않아 최신 데이터 미반영
- `refetchOnMount: 'always'`로 페이지 마운트 시마다 최신 데이터 조회

## Test plan
- [ ] 친구 페이지 진입 시 친구 리스트 API 호출 확인
- [ ] 다른 사용자가 친구 요청 승낙 후 페이지 재진입 시 리스트 업데이트 확인

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)