### PR TITLE
Fix: 루틴 생성/수정 시 이번주 월요일 이전 날짜 선택 불가 #63

### DIFF
--- a/apps/native/components/modal/RoutineFormModal.tsx
+++ b/apps/native/components/modal/RoutineFormModal.tsx
@@ -9,7 +9,7 @@ import {
   useUpdateRoutineMutation,
 } from '@repo/shared/hooks/useRoutine';
 import { routineFormValidators } from '@repo/shared/service/validatorMessage';
-import { getFormatDate } from '@repo/shared/utils';
+import { getFormatDate, getThisWeekMonday } from '@repo/shared/utils';
 import { RoutineForm } from '@repo/types';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
@@ -278,6 +278,7 @@ const RoutineFormModal = () => {
                   themeVariant={colorScheme}
                   value={value ? new Date(value) : new Date()}
                   mode="date"
+                  minimumDate={getThisWeekMonday()}
                   onChange={(_, startDate = new Date()) => {
                     setValue('startDate', getFormatDate(startDate));
 
@@ -335,6 +336,7 @@ const RoutineFormModal = () => {
                   themeVariant={colorScheme}
                   value={form.endDate ? new Date(form.endDate) : new Date()}
                   mode="date"
+                  minimumDate={getThisWeekMonday()}
                   onChange={(_, endDate = new Date()) => {
                     setValue('endDate', getFormatDate(endDate));
 

--- a/packages/shared/utils/date-utils.ts
+++ b/packages/shared/utils/date-utils.ts
@@ -24,10 +24,11 @@ export const getDisplayFormatDate = (date: Date) => {
 };
 
 export const getWeekMonday = (date: Date) => {
-  const day = date.getDay();
-  const diff = date.getDate() - day + (day === 0 ? -6 : 1);
+  const newDate = new Date(date);
+  const day = newDate.getDay();
+  const diff = newDate.getDate() - day + (day === 0 ? -6 : 1);
 
-  return getFormatDate(new Date(date.setDate(diff)));
+  return getFormatDate(new Date(newDate.setDate(diff)));
 };
 
 export const getWeekSunday = (date: Date) => {
@@ -90,3 +91,7 @@ export const getDaysOfTheWeek = () => [
   '토',
   '일',
 ];
+
+export const getThisWeekMonday = (): Date => {
+  return new Date(getWeekMonday(new Date()));
+};

--- a/packages/shared/utils/index.ts
+++ b/packages/shared/utils/index.ts
@@ -4,6 +4,7 @@ export {
   getDaysOfTheWeek,
   getDisplayFormatDate,
   getFormatDate,
+  getThisWeekMonday,
   getToday,
   getWeekMonday,
   getWeekSunday,


### PR DESCRIPTION
## Summary
- 루틴 생성/수정 시 시작 날짜와 종료 날짜를 이번주 월요일 이후로만 선택 가능하도록 제한
- 캘린더에서 이번주 월요일 이전 날짜는 disabled 처리되어 클릭 불가
- `getThisWeekMonday()` 유틸리티 함수 추가 (기존 `getWeekMonday` 활용)

## Changes
| 파일 | 변경 내용 |
|-----|---------|
| `packages/shared/utils/date-utils.ts` | `getThisWeekMonday()` 함수 추가, `getWeekMonday()` 순수 함수로 수정 |
| `packages/shared/utils/index.ts` | `getThisWeekMonday` export 추가 |
| `apps/native/components/modal/RoutineFormModal.tsx` | 시작/종료 날짜 캘린더에 `minimumDate` prop 적용 |

## Test plan
- [ ] 루틴 생성 화면에서 시작 날짜 캘린더의 이번주 월요일 이전 날짜가 disabled 됨
- [ ] 루틴 생성 화면에서 종료 날짜 캘린더의 이번주 월요일 이전 날짜가 disabled 됨
- [ ] 루틴 수정 화면에서 동일하게 동작함
- [ ] disabled 된 날짜를 클릭해도 선택되지 않음

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)